### PR TITLE
Improve v2ray JSON template.

### DIFF
--- a/v2ray/default.json
+++ b/v2ray/default.json
@@ -1,96 +1,144 @@
 {
-    "log": {
-        "loglevel": "warning",
-        "dnsLog": true
+  "dns": {
+    "hosts": {
+      "one.one.one.one": [
+        "1.1.1.1",
+        "1.0.0.1",
+        "2606:4700:4700::1111",
+        "2606:4700:4700::1001"
+      ],
+      "dns.google": [
+        "8.8.8.8",
+        "8.8.4.4",
+        "2001:4860:4860::8888",
+        "2001:4860:4860::8844"
+      ]
     },
-    "dns": {
-        "queryStrategy": "UseIPv4",
-        "servers": [
-            "1.1.1.2",
-            "https://1.0.0.2/dns-query"
+    "servers": [
+      "1.1.1.1",
+       {
+        "address": "fakedns",
+        "domains": [
+	  "domain:*.ir",
+          "domain:.ir"
         ],
-        "tag": "dns-in"
+        "expectIPs": [
+          "geoip:ir"
+       ]
+      },
+      {
+        "address": "8.8.8.8",
+        "domains": [
+	      "domain:*.ir",
+          "domain:.ir"
+        ],
+        "expectIPs": [
+          "geoip:ir"
+       ],
+        "port": 53,
+        "queryStrategy": "UseIPv4"
+      }
+    ]
+  },
+"fakedns": [
+    {
+      "ipPool": "198.18.0.0/15",
+      "poolSize": 10000
+    }
+  ],
+  "inbounds": [
+    {
+      "listen": "127.0.0.1",
+      "port": 10808,
+      "protocol": "socks",
+      "settings": {
+        "auth": "noauth",
+        "udp": true,
+        "userLevel": 8
+      },
+      "sniffing": {
+        "destOverride": [
+          "http",
+          "tls"
+        ],
+        "enabled": true,
+        "routeOnly": false
+      },
+      "tag": "socks"
     },
-    "routing": {
-        "domainStrategy": "IPIfNonMatch",
-        "rules": [
-            {
-                "domain": [
-                    "geosite:category-ads-all"
-                ],
-                "outboundTag": "block"
-            },
-            {
-                "ip": ["1.1.1.1"],
-                "port": "53",
-                "network": "udp",
-                "outboundTag": "dns-out"
-            },
-            {
-                "domain": [
-                    "regexp:.*\\.ir",
-                    "domain:.ir"
-                ],
-                "outboundTag": "direct"
-            },
-            {
-                "ip": [
-                    "geoip:ir",
-                    "geoip:private"
-                ],
-                "outboundTag": "direct"
-            }
-        ]
+    {
+      "listen": "127.0.0.1",
+      "port": 10809,
+      "protocol": "http",
+      "settings": {
+        "userLevel": 8
+      },
+      "tag": "http"
     },
-    "policy": {
-        "system": {
-            "statsOutboundDownlink": true,
-            "statsOutboundUplink": true
-        }
+    {
+      "listen": "127.0.0.1",
+      "port": 10853,
+      "protocol": "dokodemo-door",
+      "settings": {
+        "address": "1.1.1.1",
+        "network": "tcp,udp",
+        "port": 53
+      },
+      "tag": "dns-in"
+    }
+  ],
+  "log": {
+    "loglevel": "warning"
+  },
+  "outbounds": [
+    {
+      "protocol": "freedom",
+      "settings": {
+        "domainStrategy": "UseIP"
+      },
+      "tag": "direct"
     },
-    "inbounds": [
-        {
-            "port": 10808,
-            "protocol": "socks",
-            "settings": {
-                "auth": "noauth",
-                "udp": true,
-                "userLevel": 8
-            },
-            "sniffing": {
-                "destOverride": [
-                    "http",
-                    "tls"
-                ],
-                "enabled": true
-            },
-            "tag": "socks"
-        },
-        {
-            "port": 10809,
-            "protocol": "http",
-            "settings": {
-                "userLevel": 8
-            },
-            "tag": "http"
-        }
-    ],
-    "outbounds": [
-        {
-            "tag": "direct",
-            "protocol": "freedom",
-            "settings": {
-                "domainStrategy": "UseIPv4"
-            }
-        },
-        {
-            "tag": "block",
-            "protocol": "blackhole"
-        },
-        {
-            "tag": "dns-out",
-            "protocol": "dns"
-        }
-    ],
-    "stats": {}
+    {
+      "protocol": "blackhole",
+      "type": "field",
+      "tag": "block"
+    },
+    {
+      "protocol": "dns",
+      "tag": "dns-out"
+    }
+  ],
+  "routing": {
+    "domainStrategy": "IPIfNonMatch",
+    "rules": [
+      {
+        "inboundTag": [
+          "dns-in"
+        ],
+        "outboundTag": "dns-out"
+      },
+      {
+        "ip": [
+          "8.8.8.8"
+        ],
+        "outboundTag": "direct",
+        "port": "53"
+      },
+      {
+        "domain": [
+          "regexp:.*\\.ir$",
+	      "domain:*.ir",
+          "domain:.ir"
+        ],
+        "outboundTag": "direct"
+      },
+      {
+        "ip": [
+          "geoip:ir",
+          "192.168.0.0/16"
+        ],
+        "outboundTag": "direct"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Change DNSs + Add Fakedns Only for IR IP And Domains + DNS Forwarder (Dokodemo) + etc... .

I was deleted geoip:private object because gfw IPs are from 10.10.34.34, 10.10.34.35 and 10.10.34.36 (private!) , respectively, they may lead to being blocked or directed by the client core. and just add 192.168.0.0/16.

It works perfectly on all clients, even Streisand (Apple Devices) [ it doesn't crash :) ].

enjoy.